### PR TITLE
fix: open links with target=_blank in CustomTabs, same behavior as chrome PWAs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -139,6 +139,7 @@ dependencies {
     implementation 'pub.devrel:easypermissions:3.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.biometric:biometric:1.1.0"
+    implementation "androidx.browser:browser:1.4.0"
 
     kapt "com.android.databinding:compiler:3.1.4"
 

--- a/app/src/main/java/com/cylonid/nativealpha/WebViewActivity.java
+++ b/app/src/main/java/com/cylonid/nativealpha/WebViewActivity.java
@@ -51,6 +51,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.ShareCompat;
 import androidx.core.content.ContextCompat;
@@ -186,6 +187,7 @@ public class WebViewActivity extends AppCompatActivity implements EasyPermission
         wv.getSettings().setDomStorageEnabled(true);
         wv.getSettings().setAllowFileAccess(true);
         wv.getSettings().setBlockNetworkLoads(false);
+        wv.getSettings().setSupportMultipleWindows(true);
 //        wv.getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
         this.setDarkModeIfNeeded();
 
@@ -724,6 +726,27 @@ public class WebViewActivity extends AppCompatActivity implements EasyPermission
             hideSystemBars();
         }
 
+        @Override
+        public boolean onCreateWindow(WebView view, boolean isDialog,
+                                      boolean isUserGesture, android.os.Message resultMsg) {
+
+            WebView newWebView = new WebView(WebViewActivity.this);
+            view.addView(newWebView);
+            WebView.WebViewTransport transport = (WebView.WebViewTransport) resultMsg.obj;
+            transport.setWebView(newWebView);
+            resultMsg.sendToTarget();
+
+            newWebView.setWebViewClient(new WebViewClient() {
+                @Override
+                public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                    CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+                    CustomTabsIntent customTabsIntent = builder.build();
+                    customTabsIntent.launchUrl(WebViewActivity.this, Uri.parse(url));
+                    return true;
+                }
+            });
+            return true;
+        }
         @Override
         public void onPermissionRequest(PermissionRequest request) {
             List<String> permissionsToGrant = new ArrayList<>();


### PR DESCRIPTION
In a chrome-created PWA on Android, if the user clicks a link with `target=_blank` (requesting link to be opened in a new tab), the link will be opened in a newly-popped-up browser activity (CustomTabs) , instead of navigating the main app page to the link or opening it in system browser.

This behavior is particularly important for SPAs like a music player, where the user could be listening to some music and browsing around, and opening links in new tab as requested can have the music playback uninterrupted.

However in current Native Alpha behavior such a click would make the main app page to navigate to the link and interrupt the playing music in main app page. This PR fixes this and make Native Alpha behave the same as chrome PWAs.