### PR TITLE
Update status and navigation bar colors 

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -48,6 +48,8 @@
         <item name="colorSurfaceContainerHigh">@color/md_theme_surfaceContainerHigh</item>
         <item name="colorSurfaceContainerHighest">@color/md_theme_surfaceContainerHighest</item>
         <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
-        <item name="android:statusBarColor">@color/colorSignatureDark</item>
+        <item name="android:statusBarColor">@color/colorSignature</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="colorControlNormal">@android:color/white</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -47,7 +47,9 @@
         <item name="colorSurfaceContainerHigh">@color/md_theme_surfaceContainerHigh</item>
         <item name="colorSurfaceContainerHighest">@color/md_theme_surfaceContainerHighest</item>
         <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
-        <item name="android:statusBarColor">@color/colorSignatureDark</item>
+        <item name="android:statusBarColor">@color/colorSignature</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="colorControlNormal">@android:color/white</item>
     </style>
 
     <style name="AppTheme.Launcher">


### PR DESCRIPTION
Hi there :)

This PR updates the status and navigation bar colors of the main app to more closely align with modern material design. This does not modify the status or navigation bar colors within WebViews.

Additionally, this PR also fixes the color of the overflow icon in light mode, as currently it doesn't contrast well.

Screenshots:
| Before      | After      |
| ------------- | ------------- |
| <img width="200" alt="na-light-before" src="https://github.com/user-attachments/assets/9a65f741-4def-4c51-9106-c8f54cc442e4" /> | <img width="200" alt="na-light-after" src="https://github.com/user-attachments/assets/cff0022c-c751-41f4-875b-5f801cb60cb3" /> |
| <img width="200" alt="na-dark-before" src="https://github.com/user-attachments/assets/0e3a5273-2ce9-476f-99c8-0614b0e174e2" /> | <img width="200" alt="na-dark-after" src="https://github.com/user-attachments/assets/a478f453-402a-4a54-839e-06f911485994" /> |