### PR TITLE
Keep the page across process death

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -129,7 +129,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui:2.8.9'
     implementation 'com.google.code.gson:gson:2.11.0'
     implementation 'io.github.medyo:android-about-page:2.0.0'
-    implementation 'androidx.webkit:webkit:1.13.0'
+    implementation 'androidx.webkit:webkit:1.17.0'
     implementation 'com.jakewharton:process-phoenix:2.1.2'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.14.1'

--- a/app/src/main/java/com/cylonid/nativealpha/WebViewActivity.java
+++ b/app/src/main/java/com/cylonid/nativealpha/WebViewActivity.java
@@ -52,6 +52,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.app.ShareCompat;
 import androidx.core.content.ContextCompat;
 import androidx.webkit.WebSettingsCompat;
+import androidx.webkit.WebViewCompat;
 import androidx.webkit.WebViewFeature;
 
 import com.cylonid.nativealpha.databinding.DialogHttpAuthBinding;
@@ -119,6 +120,8 @@ public class WebViewActivity extends AppCompatActivity implements EasyPermission
     private AdblockProviderApiHelper adblockProviderApiHelper;
     private AdblockLifecycleHelper adblockLifecycleHelper;
 
+    private static final int MAX_SAVED_STATE_BYTES = 256 * 1024;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -135,14 +138,14 @@ public class WebViewActivity extends AppCompatActivity implements EasyPermission
             finish();
         } else {
             if(webapp.isBiometricProtection()) {
-                new BiometricPromptHelper(WebViewActivity.this).showPrompt(() -> setupWebView(), () -> finish(), getString(R.string.bioprompt_restricted_webapp));
+                new BiometricPromptHelper(WebViewActivity.this).showPrompt(() -> setupWebView(savedInstanceState), () -> finish(), getString(R.string.bioprompt_restricted_webapp));
             }
-            setupWebView();
+            setupWebView(savedInstanceState);
         }
     }
 
     @SuppressLint("ClickableViewAccessibility")
-    private void setupWebView() {
+    private void setupWebView(Bundle savedState) {
 
         String processName = Application.getProcessName();
         String packageName = this.getPackageName();
@@ -246,7 +249,9 @@ public class WebViewActivity extends AppCompatActivity implements EasyPermission
         }
 
         CUSTOM_HEADERS = initCustomHeaders(webapp.isSendSavedataRequest());
-        loadURL(wv, url);
+        if (savedState == null || wv.restoreState(savedState) == null) {
+            loadURL(wv, url);
+        }
         wv.setWebChromeClient(new CustomWebChromeClient());
         wv.setOnLongClickListener(view -> {
             if(webapp.getAlwaysUseFallbackContextMenu()) return false;
@@ -505,6 +510,14 @@ public class WebViewActivity extends AppCompatActivity implements EasyPermission
         });
 
         mPopupMenu.show();
+    }
+
+    @Override
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        if (wv != null && WebViewFeature.isFeatureSupported(WebViewFeature.SAVE_STATE)) {
+            WebViewCompat.saveState(wv, outState, MAX_SAVED_STATE_BYTES, false);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/cylonid/nativealpha/WebViewActivity.java
+++ b/app/src/main/java/com/cylonid/nativealpha/WebViewActivity.java
@@ -248,6 +248,10 @@ public class WebViewActivity extends AppCompatActivity implements EasyPermission
             wv.getSettings().setBuiltInZoomControls(true);
         }
 
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.BACK_FORWARD_CACHE)) {
+            WebSettingsCompat.setBackForwardCacheEnabled(wv.getSettings(), true);
+        }
+
         CUSTOM_HEADERS = initCustomHeaders(webapp.isSendSavedataRequest());
         if (savedState == null || wv.restoreState(savedState) == null) {
             loadURL(wv, url);


### PR DESCRIPTION
`WebViewActivity` saves no state, so when Android reclaims the process the activity
comes back on the start URL with the scroll position, open view and form contents
gone. Cookies live on disk, so it was never a logout — but every reclaim throws the
user back to the top of the app.

## Saving

Through [`WebViewCompat.saveState`][1] rather than the framework `WebView.saveState`.
The 1MB `savedInstanceState` budget is [shared by the whole process][2], and web apps
without sandboxing all live in the main one, so several open web apps can exceed it
together and crash with `TransactionTooLargeException`. The Jetpack call takes a byte
budget and drops the oldest history entries to fit, without touching the live history,
so backward navigation stays intact. Forward entries are dropped as well, since there
is no forward button in the UI.

Only saves where the WebView reports `SAVE_STATE`. Falling back to the framework call
would reintroduce exactly the crash the budget exists to prevent, so older WebViews
keep today's behaviour instead — no restore, but no new failure mode either.

The second commit turns on the back-forward cache, so going back inside a web app
restores the previous page from memory instead of re-running the load.

`androidx.webkit` goes 1.13.0 → 1.17.0 for both. It needs `minCompileSdk` 33, which is
lower than the 34 required by 1.13.0, so this is independent of the targetSdk work
in #231 and applies to `dev` as it stands.

[1]: https://developer.android.com/reference/androidx/webkit/WebViewCompat#saveState(android.webkit.WebView,android.os.Bundle,int)
[2]: https://developer.android.com/develop/ui/views/layout/webapps/manage-state

## Testing

On a Pixel running Android 17 (API 37, WebView 151), killing the backgrounded process
with `am kill` to reproduce what the system does under memory pressure:

- One web app scrolled deep into a page: comes back at the same position instead of
  at the top.
- Three web apps open at once, all in the same process, all with history: every one
  restored, no `TransactionTooLargeException`, no crash in logcat. This is the case
  the byte budget exists for.
- A web app with access restriction enabled: the prompt still appears and the content
  stays hidden until it is answered, so the biometric path is unaffected.

Not verified: that the back-forward cache actually shortens back navigation. Enabling
the flag follows the documented API, but I could not measure the difference without
instrumenting WebView's network activity, so treat that commit as untested rather than
proven.

One thing I noticed while testing and did not touch: `setupWebView()` runs
unconditionally after the biometric branch in `onCreate`, so a protected web app
issues its network request before the prompt is answered. The content is not shown —
the view is hidden — so this is not a visual leak, and it predates this change. Happy
to fix it separately if you want.
